### PR TITLE
Add URL discovery module, unit tests, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: python -m pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # pachong-crawler
+
+This is a minimal crawler project with a simple URL discovery module.
+
+## Running tests
+
+```
+pytest
+```

--- a/crawler/url_discovery.py
+++ b/crawler/url_discovery.py
@@ -1,0 +1,10 @@
+import re
+from typing import List
+
+
+def discover_urls(html: str) -> List[str]:
+    """Return a list of URLs found in the provided HTML string."""
+    if not html:
+        return []
+    pattern = re.compile(r'href=[\'\"]?(https?://[^\'\"\s>]+)')
+    return pattern.findall(html)

--- a/tests/test_url_discovery.py
+++ b/tests/test_url_discovery.py
@@ -1,0 +1,18 @@
+from crawler.url_discovery import discover_urls
+
+
+def test_discover_urls_basic():
+    html = '<a href="http://example.com">Example</a>'
+    assert discover_urls(html) == ["http://example.com"]
+
+
+def test_discover_urls_multiple():
+    html = '<a href="https://example.com/page1">One</a> <a href="http://example.com/page2">Two</a>'
+    assert discover_urls(html) == [
+        "https://example.com/page1",
+        "http://example.com/page2",
+    ]
+
+
+def test_discover_urls_none():
+    assert discover_urls("No links here!") == []


### PR DESCRIPTION
## Summary
- implement `discover_urls` in crawler package
- add pytest unit tests
- run pytest in GitHub Actions
- document test instructions in README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e59f90308832ebafe33c29b7f79fc