### PR TITLE
Add output directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ pachong-crawler 是一个示例爬虫项目，包含命令行工具和简易的 
 执行以下命令即可启动爬虫：
 
 ```bash
-python -m crawler.main --seed <起始 URL> --rate <每秒请求数>
+python -m crawler.main --seed <起始 URL> --rate <每秒请求数> --output-dir out
 ```
 
 - `--seed` 可以指定多个，用于设置爬取的初始链接。
 - `--rate` 用于控制请求频率，避免过快访问目标网站。
+- `--output-dir` 用于指定抓取结果保存目录，默认为 `data`。
 - 也可以通过 `--config` 指定 YAML/JSON 配置文件来提供这些参数。
 
 示例配置文件 `config.yaml`：
@@ -48,12 +49,31 @@ python frontend/app.py
 
 ## Docker 方式
 
-也可以通过 Docker 或 docker-compose 运行：
+也可以通过 Docker 或 docker-compose 运行。
+
+首先构建镜像：
 
 ```bash
 docker build -t pachong-crawler .
-# 或
-docker-compose up
+```
+
+镜像默认会执行 `python -m crawler.main`，脚本仅打印参数后即退出。如果想在容器中运行 Web 前端，可使用：
+
+```bash
+docker run -p 8000:8000 pachong-crawler python frontend/app.py
+```
+
+若要保存抓取结果到宿主机目录，可挂载卷并指定 `--output-dir`：
+
+```bash
+docker run -v $(pwd)/out:/data pachong-crawler \
+  python -m crawler.main --seed https://example.com --output-dir /data
+```
+
+若使用 `docker-compose`，可启动 `frontend` 服务：
+
+```bash
+docker-compose up frontend
 ```
 
 ## 运行测试

--- a/crawler/main.py
+++ b/crawler/main.py
@@ -27,6 +27,9 @@ def parse_args(argv=None):
     parser.add_argument(
         "--rate", "-r", type=float, default=None,
         help="Maximum requests per second (rate limit)")
+    parser.add_argument(
+        "--output-dir", "-o", type=Path, default=Path("data"),
+        help="Directory to store fetched pages")
     return parser.parse_args(argv)
 
 
@@ -37,11 +40,36 @@ def main(argv=None):
         config = load_config(args.config)
     seeds = args.seeds or config.get("seeds", [])
     rate = args.rate if args.rate is not None else config.get("rate")
+    output_dir = args.output_dir
+    if "output_dir" in config and args.output_dir == Path("data"):
+        output_dir = Path(config["output_dir"])
 
-    # Placeholder for starting crawl jobs
+    delay = 1.0
+    if rate:
+        if rate <= 0:
+            raise ValueError("rate must be positive")
+        delay = 1.0 / rate
+
+    from crawler import Fetcher, ObjectStore
+    from hashlib import md5
+    import sys
+
+    fetcher = Fetcher(delay=delay)
+    store = ObjectStore(output_dir)
+
     print("Starting crawler with parameters:")
     print("  Seeds:", seeds)
     print("  Rate limit:", rate, "requests/sec")
+    print("  Output directory:", output_dir)
+
+    for url in seeds:
+        try:
+            html = fetcher.fetch(url)
+            name = md5(url.encode("utf-8")).hexdigest() + ".html"
+            path = store.put(name, html.encode("utf-8"))
+            print(f"Saved {url} -> {path}")
+        except Exception as exc:
+            print(f"Failed to fetch {url}: {exc}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,11 @@ services:
     volumes:
       - .:/app
     entrypoint: ["python", "-m", "crawler.main"]
+
+  frontend:
+    build: .
+    volumes:
+      - .:/app
+    entrypoint: ["python", "frontend/app.py"]
+    ports:
+      - "8000:8000"

--- a/tests/test_main_output.py
+++ b/tests/test_main_output.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import crawler.main as main
+
+class DummyFetcher:
+    def __init__(self, delay=1.0):
+        pass
+    def fetch(self, url):
+        return "<html>dummy</html>"
+
+def test_main_stores_file(tmp_path, monkeypatch):
+    monkeypatch.setattr("crawler.fetcher.Fetcher", DummyFetcher)
+    import crawler
+    monkeypatch.setattr(crawler, "Fetcher", DummyFetcher, raising=False)
+    # Use real ObjectStore
+    output = tmp_path
+    main.main(["--seed", "http://example.com", "--output-dir", str(output)])
+    files = list(output.glob("*.html"))
+    assert len(files) == 1
+    assert files[0].read_text() == "<html>dummy</html>"


### PR DESCRIPTION
## Summary
- allow specifying `--output-dir` in `crawler.main`
- fetch seeds and save HTML pages to that directory
- document new option and Docker volume example
- add regression test for `main`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68595d1c83f4832ea3cd567f5ff19f2b