### PR TITLE
Add continuous crawler with enqueue API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 .pytest_cache/
+crawl.db

--- a/README.md
+++ b/README.md
@@ -57,24 +57,13 @@ python frontend/app.py
 docker build -t pachong-crawler .
 ```
 
-镜像默认会执行 `python -m crawler.main`，脚本仅打印参数后即退出。如果想在容器中运行 Web 前端，可使用：
+镜像默认会执行 `python -m crawler.main`。要在容器中运行持续爬取并通过 Web 界面提交 URL，可使用 `docker-compose`：
 
 ```bash
-docker run -p 8000:8000 pachong-crawler python frontend/app.py
+docker-compose up
 ```
 
-若要保存抓取结果到宿主机目录，可挂载卷并指定 `--output-dir`：
-
-```bash
-docker run -v $(pwd)/out:/data pachong-crawler \
-  python -m crawler.main --seed https://example.com --output-dir /data
-```
-
-若使用 `docker-compose`，可启动 `frontend` 服务：
-
-```bash
-docker-compose up frontend
-```
+启动后访问 <http://localhost:8000> 填写要爬取的地址，并通过 `ws://localhost:8765` 实时接收发现的链接。
 
 ## 高级异步爬虫
 
@@ -87,6 +76,16 @@ docker-compose up frontend
 ```bash
 python -m crawler.async_crawler
 ```
+
+## Live WebSocket
+
+借助 `LiveWebSocket` 模块，可以在爬虫运行时实时推送发现的链接。
+
+```bash
+python -m crawler.run_with_ws
+```
+
+启动后连接 `ws://localhost:8765` 即可接收链接消息。
 
 ## 运行测试
 

--- a/crawler/__init__.py
+++ b/crawler/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "ObjectStore",
     "AsyncCrawler",
     "SQLiteStore",
+    "LiveWebSocket",
 ]
 
 def __getattr__(name):
@@ -36,6 +37,8 @@ def __getattr__(name):
         from .async_crawler import AsyncCrawler as attr
     elif name == "SQLiteStore":
         from .async_crawler import SQLiteStore as attr
+    elif name == "LiveWebSocket":
+        from .live_ws import LiveWebSocket as attr
     else:
         raise AttributeError(name)
     globals()[name] = attr

--- a/crawler/async_crawler.py
+++ b/crawler/async_crawler.py
@@ -112,7 +112,7 @@ class AsyncCrawler:
         self._fetcher = AsyncFetcher(delay=delay)
         self._plugins = list(plugins or [])
 
-    async def crawl(self) -> None:
+    async def crawl(self, *, continuous: bool = False) -> None:
         visited = self._store.visited()
         for s in self._seeds:
             if s not in visited:
@@ -122,6 +122,9 @@ class AsyncCrawler:
             while True:
                 url = self._store.dequeue()
                 if not url:
+                    if continuous:
+                        await asyncio.sleep(1)
+                        continue
                     break
                 if url in visited:
                     continue

--- a/crawler/live_ws.py
+++ b/crawler/live_ws.py
@@ -1,0 +1,34 @@
+import asyncio
+from typing import Set
+
+import websockets
+
+
+class LiveWebSocket:
+    """Simple WebSocket broadcaster for crawler events."""
+
+    def __init__(self, host: str = "0.0.0.0", port: int = 8765) -> None:
+        self._host = host
+        self._port = port
+        self._clients: Set[websockets.WebSocketServerProtocol] = set()
+        self._server: websockets.server.Serve | None = None
+
+    async def _handler(self, websocket: websockets.WebSocketServerProtocol, path: str) -> None:
+        self._clients.add(websocket)
+        try:
+            await websocket.wait_closed()
+        finally:
+            self._clients.discard(websocket)
+
+    async def broadcast(self, message: str) -> None:
+        if not self._clients:
+            return
+        await asyncio.gather(*(ws.send(message) for ws in self._clients), return_exceptions=True)
+
+    async def start(self) -> None:
+        self._server = await websockets.serve(self._handler, self._host, self._port)
+
+    async def stop(self) -> None:
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()

--- a/crawler/run_with_ws.py
+++ b/crawler/run_with_ws.py
@@ -1,0 +1,22 @@
+"""Run AsyncCrawler and broadcast discovered URLs over WebSocket."""
+
+import asyncio
+from crawler import AsyncCrawler, SQLiteStore
+from .live_ws import LiveWebSocket
+from .discovery import discover_urls
+
+
+async def ws_plugin(ws: LiveWebSocket, url: str, html: str) -> None:
+    for link in discover_urls(html, url):
+        await ws.broadcast(link)
+
+
+async def main() -> None:
+    ws = LiveWebSocket()
+    store = SQLiteStore("crawl.db")
+    crawler = AsyncCrawler(["https://example.com"], store, plugins=[lambda u, h: ws_plugin(ws, u, h)])
+    await asyncio.gather(ws.start(), crawler.crawl(continuous=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,10 @@
 version: '3'
 services:
-  crawler:
-    build: .
-    volumes:
-      - .:/app
-    entrypoint: ["python", "-m", "crawler.main"]
-
-  frontend:
+  app:
     build: .
     volumes:
       - .:/app
     entrypoint: ["python", "frontend/app.py"]
     ports:
       - "8000:8000"
+      - "8765:8765"

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,39 +1,76 @@
-from flask import Flask, render_template_string, request
-from crawler import Fetcher, discovery
+from flask import Flask, render_template_string, request, jsonify
+import asyncio
+import threading
+
+from crawler import AsyncCrawler, SQLiteStore, discover_urls
+from crawler.live_ws import LiveWebSocket
 
 app = Flask(__name__)
-_fetcher = Fetcher()
+
+store = SQLiteStore("crawl.db")
+ws = LiveWebSocket()
+
+async def ws_plugin(url: str, html: str) -> None:
+    for link in discover_urls(html, url):
+        await ws.broadcast(link)
+
+crawler = AsyncCrawler([], store, plugins=[ws_plugin])
+loop = asyncio.new_event_loop()
+
+
+def _run_background() -> None:
+    asyncio.set_event_loop(loop)
+    loop.create_task(ws.start())
+    loop.create_task(crawler.crawl(continuous=True))
+    loop.run_forever()
+
+threading.Thread(target=_run_background, daemon=True).start()
 
 HTML_TEMPLATE = """
 <!doctype html>
 <title>Pachong Crawler</title>
 <h1>Pachong Crawler</h1>
-<form method=post>
-  URL: <input type=text name=url size=60>
-  <input type=submit value=Fetch>
+<form id="form">
+  URL: <input type=text id="url" size=60>
+  <input type=submit value="Enqueue">
 </form>
-{% if error %}<p style='color:red'>{{ error }}</p>{% endif %}
-{% if urls %}
-<h2>Discovered URLs</h2>
-<ul>
-{% for u in urls %}<li><a href='{{ u }}'>{{ u }}</a></li>{% endfor %}
-</ul>
-{% endif %}
+<ul id="results"></ul>
+<script>
+const ws = new WebSocket("ws://" + location.hostname + ":8765");
+ws.onmessage = ev => {
+  const li = document.createElement('li');
+  li.textContent = ev.data;
+  document.getElementById('results').appendChild(li);
+};
+
+document.getElementById('form').onsubmit = async ev => {
+  ev.preventDefault();
+  const url = document.getElementById('url').value;
+  await fetch('/enqueue', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({url})
+  });
+  document.getElementById('url').value = '';
+};
+</script>
 """
 
-@app.route('/', methods=['GET', 'POST'])
+
+@app.route('/')
 def index():
-    urls = []
-    error = None
-    if request.method == 'POST':
-        url = request.form.get('url', '')
-        if url:
-            try:
-                html = _fetcher.fetch(url)
-                urls = list(discovery.discover_urls(html, url))
-            except Exception as exc:
-                error = str(exc)
-    return render_template_string(HTML_TEMPLATE, urls=urls, error=error)
+    return render_template_string(HTML_TEMPLATE)
+
+
+@app.route('/enqueue', methods=['POST'])
+def enqueue():
+    data = request.get_json() or request.form
+    url = data.get('url') if data else None
+    if not url:
+        return jsonify({'error': 'missing url'}), 400
+    store.enqueue(url)
+    return jsonify({'status': 'enqueued', 'url': url})
+
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=8000, debug=True)
+    app.run(host='0.0.0.0', port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyyaml
 Flask
 aiohttp
 playwright
+websockets

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -5,3 +5,10 @@ def test_index_get():
     client = app.test_client()
     resp = client.get('/')
     assert resp.status_code == 200
+
+
+def test_enqueue_post():
+    client = app.test_client()
+    resp = client.post('/enqueue', json={'url': 'http://example.com'})
+    assert resp.status_code == 200
+    assert resp.get_json()['status'] == 'enqueued'


### PR DESCRIPTION
## Summary
- run crawler loop continuously and expose `/enqueue` endpoint
- integrate LiveWebSocket broadcasting in frontend
- simplify docker-compose to run unified app service
- document docker-compose workflow in README
- test enqueue API

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ab8a35408832e8a32b34fd493f318