### PR TITLE
Add frontend platform scraper view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [ main ]
+  pull_request:
 
 jobs:
   test:
@@ -16,6 +17,28 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements.txt
           pip install pytest
       - name: Run tests
-        run: python -m pytest
+        env:
+          PYTHONPATH: .
+        run: pytest -q
+
+  docker:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build image
+        run: |
+          docker build -t ghcr.io/${{ github.repository }}:latest .
+      - name: Log in to registry
+        if: ${{ secrets.REGISTRY_USERNAME != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Push image
+        if: ${{ secrets.REGISTRY_USERNAME != '' }}
+        run: docker push ghcr.io/${{ github.repository }}:latest

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ python frontend/app.py
 
 启动后访问 <http://localhost:8000> 即可使用。
 
+页面下方还提供按钮，可直接抓取示例电商及社交平台数据，点击后将在浏览器中显示结果。
+
 ## Docker 方式
 
 也可以通过 Docker 或 docker-compose 运行。
@@ -97,4 +99,25 @@ python -m crawler.run_with_ws
 ```bash
 PYTHONPATH=. pytest -q
 ```
+
+## 平台数据抓取
+
+`crawler/platform_runner.py` 和前端界面都演示了如何抓取示例电商和社交平台的数据：
+
+```bash
+python -m crawler.platform_runner
+```
+
+脚本将输出从 `fakestoreapi.com` 取得的商品信息以及来自 `jsonplaceholder.typicode.com`
+的热门贴文列表，可作为扩展到真实平台的参考。
+
+## CI/CD
+
+项目内置 GitHub Actions 工作流 `.github/workflows/ci.yml`，在推送或提交 PR 时会：
+
+1. 安装依赖并执行测试。
+2. 构建 Docker 镜像并（在配置了 `REGISTRY_USERNAME` 与 `REGISTRY_PASSWORD`
+   secrets 的情况下）推送到 `ghcr.io`。
+
+推送完成后即可在本地通过 `docker pull ghcr.io/<owner>/<repo>:latest` 拉取并测试镜像。
 

--- a/crawler/platform_runner.py
+++ b/crawler/platform_runner.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from .platforms.ecommerce import FakeStorePlatform
+from .platforms.social import FakeSocialPlatform
+
+
+def main() -> None:
+    ecommerce = FakeStorePlatform()
+    social = FakeSocialPlatform()
+
+    print("E-commerce products:")
+    for item in ecommerce.fetch_items():
+        print(item)
+
+    print("\nSocial trending posts:")
+    for item in social.fetch_items():
+        print(item)
+
+
+if __name__ == "__main__":
+    main()

--- a/crawler/platforms/__init__.py
+++ b/crawler/platforms/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Iterable, Any
+
+from ..fetcher import Fetcher
+
+
+class Platform(ABC):
+    """Base class for platform-specific scrapers."""
+
+    def __init__(self, fetcher: Fetcher | None = None) -> None:
+        self.fetcher = fetcher or Fetcher()
+
+    @abstractmethod
+    def fetch_items(self) -> Iterable[dict[str, Any]]:
+        """Return items gathered from the platform."""
+        pass

--- a/crawler/platforms/ecommerce.py
+++ b/crawler/platforms/ecommerce.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Iterable, Any
+
+from . import Platform
+
+
+class FakeStorePlatform(Platform):
+    """Example e-commerce data source using the fakestoreapi."""
+
+    API_URL = "https://fakestoreapi.com/products"
+
+    def fetch_items(self) -> Iterable[dict[str, Any]]:
+        data = self.fetcher.fetch(self.API_URL, json=True)
+        for item in data:
+            yield {
+                "id": item.get("id"),
+                "title": item.get("title"),
+                "price": item.get("price"),
+            }

--- a/crawler/platforms/social.py
+++ b/crawler/platforms/social.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Iterable, Any
+
+from . import Platform
+
+
+class FakeSocialPlatform(Platform):
+    """Example social data source using jsonplaceholder posts."""
+
+    API_URL = "https://jsonplaceholder.typicode.com/posts"
+
+    def fetch_items(self) -> Iterable[dict[str, Any]]:
+        data = self.fetcher.fetch(self.API_URL, json=True)
+        for item in data[:10]:  # take a subset as "trending"
+            yield {
+                "id": item.get("id"),
+                "title": item.get("title"),
+                "url": f"{self.API_URL}/{item.get('id')}",
+            }

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -12,3 +12,28 @@ def test_enqueue_post():
     resp = client.post('/enqueue', json={'url': 'http://example.com'})
     assert resp.status_code == 200
     assert resp.get_json()['status'] == 'enqueued'
+
+
+def test_platform_endpoints(monkeypatch):
+    client = app.test_client()
+
+    class DummyFetcher:
+        def fetch(self, url: str, json: bool = False):
+            if 'fakestoreapi' in url:
+                return [{'id': 1, 'title': 'Item', 'price': 9.99}]
+            if 'jsonplaceholder' in url:
+                return [{'id': 1, 'title': 'Post'}]
+            return []
+
+    import crawler.platforms as cp
+    monkeypatch.setattr(cp, 'Fetcher', DummyFetcher)
+
+    resp = client.get('/platform/ecommerce')
+    assert resp.status_code == 200
+    assert resp.get_json() == [{'id': 1, 'title': 'Item', 'price': 9.99}]
+
+    resp = client.get('/platform/social')
+    assert resp.status_code == 200
+    assert resp.get_json() == [
+        {'id': 1, 'title': 'Post', 'url': 'https://jsonplaceholder.typicode.com/posts/1'}
+    ]

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -1,0 +1,27 @@
+from crawler.platforms.ecommerce import FakeStorePlatform
+from crawler.platforms.social import FakeSocialPlatform
+
+
+class DummyFetcher:
+    def fetch(self, url: str, json: bool = False):
+        if "fakestoreapi" in url:
+            return [{"id": 1, "title": "Item", "price": 9.99}]
+        if "jsonplaceholder" in url:
+            return [{"id": 1, "title": "Post"}]
+        return []
+
+
+def test_ecommerce_fetch(monkeypatch):
+    platform = FakeStorePlatform()
+    monkeypatch.setattr(platform, "fetcher", DummyFetcher())
+    items = list(platform.fetch_items())
+    assert items == [{"id": 1, "title": "Item", "price": 9.99}]
+
+
+def test_social_fetch(monkeypatch):
+    platform = FakeSocialPlatform()
+    monkeypatch.setattr(platform, "fetcher", DummyFetcher())
+    items = list(platform.fetch_items())
+    assert items == [
+        {"id": 1, "title": "Post", "url": "https://jsonplaceholder.typicode.com/posts/1"}
+    ]


### PR DESCRIPTION
## Summary
- extend Flask app with buttons to fetch ecommerce & social sample data
- expose `/platform/<name>` endpoint returning scraper results
- document platform buttons in README
- test new endpoint behavior

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68873cd5fb98832e83d7a82b9219f82b